### PR TITLE
Fix For the Calibre Web Folder

### DIFF
--- a/apps/calibre-web/docker-compose.yml
+++ b/apps/calibre-web/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - TZ=${TZ}
     volumes:
       - ${APP_DATA_DIR}/data/config:/config
-      - ${ROOT_FOLDER_HOST}/media/data/books:/books
+      - ${APP_DATA_DIR}/data/books:/books
     ports:
       - ${APP_PORT}:8083
     restart: unless-stopped


### PR DESCRIPTION
The Folder needs to point to the Calibre DB that is copied over.