### PR TITLE
Update tipi version and added URL environment variable

### DIFF
--- a/apps/n8n/config.json
+++ b/apps/n8n/config.json
@@ -5,8 +5,8 @@
   "exposable": true,
   "port": 8094,
   "id": "n8n",
-  "tipi_version": 12,
-  "version": "0.224.1",
+  "tipi_version": 13,
+  "version": "0.229.0",
   "categories": [
     "automation"
   ],

--- a/apps/n8n/docker-compose.yml
+++ b/apps/n8n/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   n8n:
     container_name: n8n
-    image: n8nio/n8n:0.224.1
+    image: n8nio/n8n:0.229.0
     restart: unless-stopped
     ports:
       - ${APP_PORT}:5678
@@ -17,6 +17,7 @@ services:
       - DB_POSTGRESDB_PORT=5432
       - DB_POSTGRESDB_USER=tipi
       - DB_POSTGRESDB_PASSWORD=tipi
+      - N8N_EDITOR_BASE_URL=${APP_DOMAIN}
     depends_on:
       - db-n8n
     networks:

--- a/apps/n8n/metadata/description.md
+++ b/apps/n8n/metadata/description.md
@@ -1,3 +1,7 @@
+## Installation Notes ##
+
+For integrations which authorize with OAUTH you will need to enable "expose app" and a URL when setting n8n up. This setting can be changed after installation if you find an integration you would like to use.
+
 ## Easily automate tasks across different services. 
 
 n8n is an extendable workflow automation tool. With a fair-code distribution model, n8n will always have visible source code, be available to self-host, and allow you to add your own custom functions, logic and apps. n8n's node-based approach makes it highly 

--- a/apps/n8n/metadata/description.md
+++ b/apps/n8n/metadata/description.md
@@ -1,6 +1,6 @@
 ## Installation Notes ##
 
-For integrations which authorize with OAUTH you will need to enable "expose app" and a URL when setting n8n up. This setting can be changed after installation if you find an integration you would like to use.
+To enable OAUTH integrations you will need to enable the "expose app" option and configure a URL in Tipi. This setting can be changed at a later date if an integration is identified that needs it.
 
 ## Easily automate tasks across different services. 
 


### PR DESCRIPTION
Updated to the latest version and added an environment variable for the domain which is necessary when setting up integrations that have OAUTH2 callbacks, otherwise the callback URL is localhost, which is not functional.

One thing I am not clear on is what ${APP_DOMAIN} returns if the URL is not set to exposed inside of Tipi. Does this need to be conditional?