### PR TITLE
fix(common):  network.external.name is deprecated

### DIFF
--- a/apps/docker-compose.common.yml
+++ b/apps/docker-compose.common.yml
@@ -1,6 +1,6 @@
-version: "3.7"
+version: "3.9"
 
 networks:
   tipi_main_network:
-      external:
-        name: runtipi_tipi_main_network
+    name: runtipi_tipi_main_network
+    external: true


### PR DESCRIPTION
This PR fix this warn log:

$ runtipi/logs/app.log

```
2023-08-15T23:49:00.780Z > EventDispatcher: app efpm5oo finished with message: Starting app script
time="2023-08-16T01:48:59+02:00" level=warning msg="network tipi_main_network: network.external.name is deprecated. Please set network.name with external: true"
```