### PR TITLE
Make Jackett use latest version

### DIFF
--- a/apps/jackett/config.json
+++ b/apps/jackett/config.json
@@ -5,8 +5,8 @@
   "exposable": true,
   "port": 8097,
   "id": "jackett",
-  "tipi_version": 79,
-  "version": "0.21.689",
+  "tipi_version": 80,
+  "version": "latest",
   "description": "Jackett works as a proxy server: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato, Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific http queries, parses the html or json response, and then sends results back to the requesting software. This allows for getting recent uploads (like RSS) and performing searches.",
   "short_desc": "API Support for your favorite torrent trackers ",
   "categories": [

--- a/apps/jackett/docker-compose.yml
+++ b/apps/jackett/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   jackett:
-    image: lscr.io/linuxserver/jackett:0.21.689
+    image: lscr.io/linuxserver/jackett:latest
     container_name: jackett
     environment:
       - PUID=1000


### PR DESCRIPTION
Jackett gets updated by renovate bot *very* frequently - If you check the version tag it's now up at 80 updates. I think for this use case it makes a lot of sense to just put it at `latest`. It's a web crawler, if you use the old release of a web crawler it's usually just broken. And the constant updating is annoying.