### PR TITLE
Fix pihole error.

### DIFF
--- a/apps/pihole/config.json
+++ b/apps/pihole/config.json
@@ -10,7 +10,7 @@
     ]
   },
   "id": "pihole",
-  "tipi_version": 8,
+  "tipi_version": 9,
   "version": "2023.05.2",
   "url_suffix": "/admin",
   "categories": [

--- a/apps/pihole/docker-compose.yml
+++ b/apps/pihole/docker-compose.yml
@@ -18,12 +18,10 @@ services:
     environment:
       TZ: ${TZ}
       WEBPASSWORD: ${APP_PASSWORD}
-      FTLCONF_REPLY_ADDR4: 10.21.21.201
     cap_add:
       - NET_ADMIN
     networks:
-      tipi_main_network:
-        ipv4_address: 10.21.21.201
+      - tipi_main_network
     labels:
       # Main
       traefik.enable: true


### PR DESCRIPTION
Pihole had an error in version 1.6.0 in the docker-compose file and it wouldn't start, this is a simple fix for that.