### PR TITLE
chore: update halo config

### DIFF
--- a/apps/halo/config.json
+++ b/apps/halo/config.json
@@ -24,17 +24,6 @@
       "env_variable": "HALO_DATABASE_PASSWORD"
     },
     {
-      "type": "text",
-      "label": "Initial admin username",
-      "env_variable": "HALO_ADMIN_USERNAME"
-    },
-    {
-      "type": "text",
-      "label": "Initial admin password",
-      "min": 8,
-      "env_variable": "HALO_ADMIN_PASSWORD"
-    },
-    {
       "type": "url",
       "label": "External url",
       "env_variable": "HALO_EXTERNAL_URL"

--- a/apps/halo/docker-compose.yml
+++ b/apps/halo/docker-compose.yml
@@ -27,8 +27,6 @@ services:
       - --spring.r2dbc.password=${HALO_DATABASE_PASSWORD}
       - --spring.sql.init.platform=postgresql
       - --halo.external-url=${HALO_EXTERNAL_URL}
-      - --halo.security.initializer.superadminusername=${HALO_ADMIN_USERNAME}
-      - --halo.security.initializer.superadminpassword=${HALO_ADMIN_PASSWORD}
     labels:
       # Main
       traefik.enable: true


### PR DESCRIPTION
Remove the configuration of the initial administrator, and the registration of the administrator on the initialization page is already supported in 2.9.