### PR TITLE
fix(forgejo): correct db password

### DIFF
--- a/apps/forgejo/docker-compose.yml
+++ b/apps/forgejo/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - FORGEJO__database__HOST=forgejo-db:5432
       - FORGEJO__database__NAME=forgejo
       - FORGEJO__database__USER=forgejo
-      - FORGEJO__database__PASSWD=forgejo
+      - FORGEJO__database__PASSWD=${FORGEJO_DB_PASSWORD}
     restart: unless-stopped
     volumes:
       - ${APP_DATA_DIR}/data/forgejo:/data


### PR DESCRIPTION
## Purpose
Forgejo container was not using the correct db password resulting in an error when trying to run the app