### PR TITLE
App updates

### DIFF
--- a/apps/ghostfolio/config.json
+++ b/apps/ghostfolio/config.json
@@ -5,8 +5,8 @@
   "available": true,
   "exposable": true,
   "id": "ghostfolio",
-  "tipi_version": 7,
-  "version": "1.305.0",
+  "tipi_version": 8,
+  "version": "2.9.0",
   "categories": [
     "finance"
   ],

--- a/apps/ghostfolio/config.json
+++ b/apps/ghostfolio/config.json
@@ -5,8 +5,8 @@
   "available": true,
   "exposable": true,
   "id": "ghostfolio",
-  "tipi_version": 8,
-  "version": "2.9.0",
+  "tipi_version": 9,
+  "version": "2.10.0",
   "categories": [
     "finance"
   ],

--- a/apps/ghostfolio/docker-compose.yml
+++ b/apps/ghostfolio/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   ghostfolio:
     container_name: ghostfolio
-    image: ghostfolio/ghostfolio:2.9.0
+    image: ghostfolio/ghostfolio:2.10.0
     restart: unless-stopped
     ports:
       - ${APP_PORT}:3333

--- a/apps/ghostfolio/docker-compose.yml
+++ b/apps/ghostfolio/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   ghostfolio:
     container_name: ghostfolio
-    image: ghostfolio/ghostfolio:1.305.0
+    image: ghostfolio/ghostfolio:2.9.0
     restart: unless-stopped
     ports:
       - ${APP_PORT}:3333

--- a/apps/jellyfin/config.json
+++ b/apps/jellyfin/config.json
@@ -5,8 +5,8 @@
   "exposable": true,
   "port": 8091,
   "id": "jellyfin",
-  "tipi_version": 6,
-  "version": "10.8.10",
+  "tipi_version": 7,
+  "version": "10.8.11",
   "categories": [
     "media"
   ],

--- a/apps/jellyfin/docker-compose.yml
+++ b/apps/jellyfin/docker-compose.yml
@@ -17,25 +17,27 @@ services:
     networks:
       - tipi_main_network
     labels:
-      traefik.enable: ${APP_EXPOSED}
-      traefik.http.middlewares.jellyfin-mw.headers.SSLForceHost: true
-      traefik.http.middlewares.jellyfin-mw.headers.SSLHost: ${APP_DOMAIN}
-      traefik.http.middlewares.jellyfin-mw.headers.SSLRedirect: true
-      traefik.http.middlewares.jellyfin-mw.headers.STSIncludeSubdomains: true
-      traefik.http.middlewares.jellyfin-mw.headers.STSPreload: true
-      traefik.http.middlewares.jellyfin-mw.headers.STSSeconds: 315360000
-      traefik.http.middlewares.jellyfin-mw.headers.browserXSSFilter: true
-      traefik.http.middlewares.jellyfin-mw.headers.contentTypeNosniff: true
-      traefik.http.middlewares.jellyfin-mw.headers.customFrameOptionsValue: 'allow-from https://${DOMAIN}'
-      traefik.http.middlewares.jellyfin-mw.headers.customResponseHeaders.X-Robots-Tag: noindex,nofollow,nosnippet,noarchive,notranslate,noimageindex
-      traefik.http.middlewares.jellyfin-mw.headers.forceSTSHeader: true
-      traefik.http.middlewares.jellyfin-mw.headers.frameDeny: true
-      traefik.http.routers.jellyfin.entryPoints: websecure
-      traefik.http.routers.jellyfin.middlewares: jellyfin-mw
+      # Main
+      traefik.enable: true
+      traefik.http.middlewares.jellyfin-web-redirect.redirectscheme.scheme: https
+      traefik.http.services.jellyfin.loadbalancer.server.port: 8096
+      # Web
+      traefik.http.routers.jellyfin-insecure.rule: Host(`${APP_DOMAIN}`)
+      traefik.http.routers.jellyfin-insecure.entrypoints: web
+      traefik.http.routers.jellyfin-insecure.service: jellyfin
+      traefik.http.routers.jellyfin-insecure.middlewares: jellyfin-web-redirect
+      # Websecure
       traefik.http.routers.jellyfin.rule: Host(`${APP_DOMAIN}`)
-      traefik.http.routers.jellyfin.service: jellyfin-svc
-      traefik.http.routers.jellyfin.tls: true
+      traefik.http.routers.jellyfin.entrypoints: websecure
+      traefik.http.routers.jellyfin.service: jellyfin
       traefik.http.routers.jellyfin.tls.certresolver: myresolver
-      traefik.http.routers.jellyfin.tls.domains: ${APP_DOMAIN}
-      traefik.http.services.jellyfin-svc.loadBalancer.passHostHeader: true
-      traefik.http.services.jellyfin-svc.loadBalancer.server.port: 8096
+      # Local domain
+      traefik.http.routers.jellyfin-local-insecure.rule: Host(`jellyfin.${LOCAL_DOMAIN}`)
+      traefik.http.routers.jellyfin-local-insecure.entrypoints: web
+      traefik.http.routers.jellyfin-local-insecure.service: jellyfin
+      traefik.http.routers.jellyfin-local-insecure.middlewares: jellyfin-web-redirect
+      # Local domain secure
+      traefik.http.routers.jellyfin-local.rule: Host(`jellyfin.${LOCAL_DOMAIN}`)
+      traefik.http.routers.jellyfin-local.entrypoints: websecure
+      traefik.http.routers.jellyfin-local.service: jellyfin
+      traefik.http.routers.jellyfin-local.tls: true

--- a/apps/jellyfin/docker-compose.yml
+++ b/apps/jellyfin/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   jellyfin:
-    image: lscr.io/linuxserver/jellyfin:10.8.10
+    image: lscr.io/linuxserver/jellyfin:10.8.11
     container_name: jellyfin
     volumes:
       - ${APP_DATA_DIR}/data/config:/config

--- a/apps/radarr/config.json
+++ b/apps/radarr/config.json
@@ -5,8 +5,8 @@
   "exposable": true,
   "port": 8088,
   "id": "radarr",
-  "tipi_version": 9,
-  "version": "4.7.5",
+  "tipi_version": 10,
+  "version": "5.0.3",
   "categories": [
     "media",
     "utilities"

--- a/apps/radarr/docker-compose.yml
+++ b/apps/radarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   radarr:
-    image: lscr.io/linuxserver/radarr:4.7.5
+    image: lscr.io/linuxserver/radarr:5.0.3
     container_name: radarr
     environment:
       - PUID=1000


### PR DESCRIPTION
Some assorted app updates that weren't picked up by mend renovate. Also I updated Ghostfolio to 2.10, it all works. You can then also close https://github.com/meienberger/runtipi-appstore/pull/1176 as superseded.